### PR TITLE
Change like-post relationship to be One to Many, set Count field in P…

### DIFF
--- a/backend/apps/Comment/models.py
+++ b/backend/apps/Comment/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from ..User.models import Author
+from ..Post.models import Post
 
 CONTENT_TYPE_CHOICES = [
     ("text/markdown", "Common Mark"),
@@ -16,4 +17,5 @@ class Comment(models.Model):
     published = models.DateTimeField(auto_now_add=True)                    # when the comment was made
     author = models.ForeignKey(Author, on_delete=models.CASCADE)  # the author who made the comment
     comment = models.CharField(max_length=5000)
-    contentType = models.CharField(choices = CONTENT_TYPE_CHOICES, max_length=100)
+    post = models.ForeignKey(Post, on_delete=models.CASCADE)
+    contentType = models.CharField(choices = CONTENT_TYPE_CHOICES, max_length=100, default="")

--- a/backend/apps/Like/admin.py
+++ b/backend/apps/Like/admin.py
@@ -1,3 +1,5 @@
 from django.contrib import admin
+from .models import Like
 
 # Register your models here.
+admin.site.register(Like)

--- a/backend/apps/Like/models.py
+++ b/backend/apps/Like/models.py
@@ -1,4 +1,6 @@
+from tkinter import CASCADE
 from django.db import models
+
 from ..User.models import Author
 
 
@@ -6,7 +8,6 @@ from ..User.models import Author
 class Like(models.Model):
     date = models.DateTimeField(auto_now_add=True)                    # when the like was done
     author = models.ForeignKey(Author, on_delete=models.CASCADE)  # the author who liked this
-
-
+    post = models.ForeignKey('Post.Post', on_delete=models.CASCADE)
 
 

--- a/backend/apps/Post/admin.py
+++ b/backend/apps/Post/admin.py
@@ -2,8 +2,8 @@ from django.contrib import admin
 from .models import Category, Post
 
 class PostAdmin(admin.ModelAdmin):
-    list_display = ('type', 'title', 'id', 'source', 'origin', 'description', 
-    'contentType', 'content', 'author', 'get_categories', 'count', 'comments', 'published',
+    list_display = ('title', 'id', 'description', 
+    'contentType', 'content', 'author', 'get_categories', 'comments', 'published',
     'visibility', 'unlisted')
 
 admin.site.register(Post, PostAdmin)

--- a/backend/apps/Post/models.py
+++ b/backend/apps/Post/models.py
@@ -1,6 +1,5 @@
 from imp import source_from_cache
 from tokenize import blank_re
-from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from ..User.models import Author
 from ..Like.models import Like
@@ -18,14 +17,18 @@ VISIBILITY_CHOICES = [
     ("FRIENDS", "FRIENDS"),
 ]
 
+
+
 class Category(models.Model):
     name=models.CharField(max_length=50)
 
     def __str__(self) -> str:
         return self.name
 
+
 # Create your models here.
 class Post(models.Model):
+
     type = models.CharField(default="post", editable=False, max_length=4)
     title = models.CharField(max_length=30, default="Untitled", unique=True)
     source = models.SlugField(max_length=100, editable=False)
@@ -33,14 +36,13 @@ class Post(models.Model):
     description = models.CharField(max_length=200, blank=True)
     contentType = models.CharField(choices = CONTENT_TYPE_CHOICES, max_length=100)
     content = models.TextField()
-    likes = models.ManyToManyField(Like, blank=True)
     author = models.ForeignKey(Author, on_delete=models.CASCADE) #Switch to OneToOne field with User
     categories = models.ManyToManyField(Category, blank=True)
-    count = models.IntegerField(default=0, editable=False)
     comments = models.URLField(max_length=100, default="") 
+    count = models.IntegerField(default=0, editable=False)
     published = models.DateTimeField(auto_now_add=True)
     visibility = models.CharField(choices=VISIBILITY_CHOICES, max_length=100, default="PUBLIC")
     unlisted = models.BooleanField(default=False)
-
+        
     def get_categories(self):
         return "\n".join([str(c) for c in self.categories.all()])

--- a/backend/apps/Post/serializers.py
+++ b/backend/apps/Post/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Category, Post
+from .models import Category, Post, Like
 
 class CategorySerializer(serializers.ModelSerializer):
     class Meta:
@@ -9,10 +9,13 @@ class CategorySerializer(serializers.ModelSerializer):
 class PostSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
-        fields = '__all__'
+        fields = ('type', 'title', 'id', 'source', 'origin', 'description', 
+    'contentType', 'content', 'author', 'categories', 'comments', 'count', 'published',
+    'visibility', 'unlisted')
 
     def to_representation(self, instance):
         rep = super().to_representation(instance)
         rep["categories"] = [cat['name'] for cat in CategorySerializer(instance.categories.all(), many=True).data]
+        rep["count"] = Like.objects.filter(post_id = instance.id).count()
         return rep
 


### PR DESCRIPTION
1. Inside of Like, have a foreign key field associating to Post. Then, multiple posts can be associated with a Like object, but each Like object can only be associated to one post. 

2.  Similarly, have a ForeignKey field associating a Like to an author. Now one author can have multiple Likes, but each Like can only have one author.  

3. Kept the count integer field, but in the serializer update the representation to count all associated like objects. 